### PR TITLE
Fix wrong check for stopped propagation inside daemonShouldRun method.

### DIFF
--- a/src/Util/CacheAdapter.php
+++ b/src/Util/CacheAdapter.php
@@ -51,7 +51,7 @@ class CacheAdapter implements CacheInterface
      */
     public function get($key, $default = null)
     {
-        $this->cache->get($key, $default);
+        return $this->cache->get($key, $default);
     }
 
     /**

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -175,7 +175,7 @@ class Worker
     {
         return ! (($this->manager->isDownForMaintenance() && ! $options->force) ||
             $this->paused ||
-            $this->until() === false);
+            $this->until() !== false);
     }
 
     /**

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -171,10 +171,10 @@ class Worker
      *
      * @return bool
      */
-    protected function daemonShouldRun(WorkerOptions $options)
+    public function daemonShouldRun(WorkerOptions $options)
     {
         return ! (($this->manager->isDownForMaintenance() && ! $options->force) ||
-            $this->paused ||
+            $this->isPaused() ||
             $this->until() !== false);
     }
 
@@ -660,6 +660,14 @@ class Worker
     protected function until()
     {
         return $this->events->dispatch(EventsList::LOOPING, new Event\Looping)->isPropagationStopped();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPaused()
+    {
+        return $this->paused;
     }
 
     /**

--- a/tests/Util/CacheAdapterTest.php
+++ b/tests/Util/CacheAdapterTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace IdeasBucket\QueueBundle\Util;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+
+class CacheAdapterTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testGetter()
+    {
+        $cacheMock = m::mock(CacheInterface::class)
+                      ->shouldReceive('get')
+                      ->once()
+                      ->andReturn('test')
+                      ->getMock();
+
+        $class = new CacheAdapter($cacheMock);
+
+
+        $this->assertEquals('test', $class->get('test'));
+    }
+
+}

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -2,6 +2,7 @@
 
 namespace IdeasBucket\QueueBundle;
 
+use IdeasBucket\QueueBundle\Event\EventsList;
 use IdeasBucket\QueueBundle\Event\JobExceptionOccurred;
 use IdeasBucket\QueueBundle\Event\JobFailed;
 use IdeasBucket\QueueBundle\Event\JobProcessed;
@@ -9,11 +10,12 @@ use IdeasBucket\QueueBundle\Event\JobProcessing;
 use IdeasBucket\QueueBundle\Exception\ErrorHandler;
 use IdeasBucket\QueueBundle\Exception\MaxAttemptsExceededException;
 use IdeasBucket\QueueBundle\Job\JobsInterface;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Mockery as m;
+use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use IdeasBucket\QueueBundle\Event\EventsList;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class WorkerTest
@@ -156,6 +158,91 @@ class WorkerTest extends TestCase
         $worker->runNextJob('default', 'queue', $this->workerOptions(['maxTries' => 1]));
         $this->assertFalse($job->deleted);
         $this->assertNull($job->failedWith);
+    }
+
+    public function testDaemonShouldRunMaintenanceAndForce()
+    {
+        $manager = m::mock(Manager::class)
+                    ->shouldReceive('isDownForMaintenance')
+                    ->andReturn(true)
+                    ->getMock();
+
+        $eventMock = m::mock(Event::class)
+                      ->shouldReceive('isPropagationStopped')
+                      ->andReturn(false)
+                      ->getMock();
+
+        $dispatcher = m::mock(EventDispatcherInterface::class)
+                       ->shouldReceive('dispatch')
+                       ->andReturn($eventMock)
+                       ->getMock();
+
+        $exceptionHandler = m::mock(ErrorHandler::class)->makePartial();
+
+        /** @var Worker|m\Mock $worker */
+        $worker = m::mock(Worker::class, [$manager, $dispatcher, $exceptionHandler])
+                   ->makePartial()
+                   ->shouldReceive('isPaused')
+                   ->andReturn(false)
+                   ->getMock();
+
+        $workerOptions = new WorkerOptions();
+
+        $bool = $worker->daemonShouldRun($workerOptions);
+
+        $this->assertFalse($bool);
+
+        // Now test forced
+        $workerOptions = new WorkerOptions();
+        $workerOptions->force = true;
+
+        $bool = $worker->daemonShouldRun($workerOptions);
+        $this->assertTrue($bool);
+    }
+
+    public function testDaemonShouldRunUntilAndPaused(){
+        $manager = m::mock(Manager::class)
+                    ->shouldReceive('isDownForMaintenance')
+                    ->andReturn(false)
+                    ->getMock();
+
+        $eventMock = m::mock(Event::class)
+                      ->shouldReceive('isPropagationStopped')
+                      ->andReturnValues([true, false])
+                      ->getMock();
+
+        $dispatcher = m::mock(EventDispatcherInterface::class)
+                       ->shouldReceive('dispatch')
+                       ->andReturn($eventMock)
+                       ->getMock();
+
+        $exceptionHandler = m::mock(ErrorHandler::class)->makePartial();
+
+        /** @var Worker|m\Mock $worker */
+        $worker = m::mock(Worker::class, [$manager, $dispatcher, $exceptionHandler])
+                   ->makePartial()
+                   ->shouldReceive('isPaused')
+                   ->andReturn(false)
+                   ->getMock();
+
+        $workerOptions = new WorkerOptions();
+
+        // Run once with isPropagationStopped = false
+        $bool = $worker->daemonShouldRun($workerOptions);
+        $this->assertFalse($bool);
+
+        // Run with isPropagationStopped = true
+        $bool = $worker->daemonShouldRun($workerOptions);
+        $this->assertTrue($bool);
+
+        $worker = m::mock(Worker::class, [$manager, $dispatcher, $exceptionHandler])
+                   ->makePartial()
+                   ->shouldReceive('isPaused')
+                   ->andReturn(true)
+                   ->getMock();
+
+        $bool = $worker->daemonShouldRun($workerOptions);
+        $this->assertFalse($bool);
     }
 
     /**


### PR DESCRIPTION
There was a wrong check if some listener stopped the propagation of the loop event. Thus leading to daemon not working at all.